### PR TITLE
Updates aws-sdk from v2 to v3

### DIFF
--- a/lib/upload-s3.js
+++ b/lib/upload-s3.js
@@ -1,49 +1,57 @@
-const AWS = require('aws-sdk')
+const { Upload } = require('@aws-sdk/lib-storage')
+const { S3, S3Client } = require('@aws-sdk/client-s3')
 const Timer = require('./timer')
+const { PassThrough, pipeline } = require('stream')
 
-// configure AWS to log to stdout
-AWS.config.update({
-    logger: process.stdout
-})
-
-module.exports = function (stream, config, key) {
+module.exports = async (stream, { S3_BUCKET, S3_REGION, S3_STORAGE_CLASS, S3_URL }, Key) => {
     if (!stream || typeof stream.on !== 'function') {
         throw new Error('invalid stream provided')
     }
-    return new Promise((resolve, reject) => {
-        const timer = new Timer();
+
+    const passThrough = new PassThrough()
+    pipeline(stream, passThrough, () => {})
+
+    try {
+        const timer = new Timer()
         console.log(
-            'streaming dump to s3 ' +
-            `bucket=${config.S3_BUCKET}, ` +
-            `key=${key} ` +
-            `region=${config.S3_REGION}` +
-            `storageclass=${config.S3_STORAGE_CLASS}` +
-            `url=${config.S3_URL}`
-        )
-        const s3 = new AWS.S3({
-            params: {
-                Bucket: config.S3_BUCKET,
-                Key: key,
-                //ACL: 'bucket-owner-full-control',
-                StorageClass: config.S3_STORAGE_CLASS
-            }
-        })
+          'streaming dump to s3 ' +
+          `bucket=${S3_BUCKET}, ` +
+          `key=${Key} ` +
+          `region=${S3_REGION} ` +
+          `storageclass=${S3_STORAGE_CLASS} ` +
+          `url=${S3_URL}`
+      )
+
+        const clientOpts = {
+            region: `${S3_REGION}`
+        }
 
         // begin upload to s3
-        s3.upload({
-            Body: stream
+        const upload = new Upload({
+            client: new S3(clientOpts) || new S3Client(clientOpts),
+
+            params: {
+                Body: passThrough,
+                Bucket: `${S3_BUCKET}`,
+                Key,
+              // ACL: 'bucket-owner-full-control',
+                StorageClass: `${S3_STORAGE_CLASS}`
+            },
+
+            leavePartsOnError: true
         })
-        .send((err, data) => {
-            if (err) {
-                reject(err)
-            }
-            else {
-                console.log(
+        upload.on('httpUploadProgress', (progress) => {
+            console.log(progress)
+        })
+
+        const data = await upload.done()
+        console.log(
                     'SUCCESS: The backup was uploaded to ' +
                     `${data.Location} in ${timer.elapsedString()}`
                 )
-                resolve(data.Location)
-            }
-        })
-    })
+        return data.Location
+    }
+    catch (error) {
+        console.log(error)
+    }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "through2": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.290.0",
+    "@aws-sdk/lib-storage": "^3.290.0",
     "cron": "^1.2.1",
-    "aws-sdk": "^2.45.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "coveralls": "^2.13.0",
@@ -23,7 +24,8 @@
     "mock-spawn": "^0.2.6",
     "nyc": "^10.2.0",
     "rewire": "^2.5.2",
-    "sinon": "^2.1.0"
+    "sinon": "^2.1.0",
+    "stream": "^0.0.2"
   },
   "scripts": {
     "test": "mocha test",


### PR DESCRIPTION
Main changes:

* Use the new `@aws-sdk/lib-storage` and `@aws-sdk/client-s3` packages instead of the old `aws-sdk` package
* [Global `AWS.config` is no longer supported](https://github.com/aws/aws-sdk-js-v3#configuration). Push this down into the configuration for the client.
* Refactor from promises chaining [to async/await as recommended](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/index.html#asyncawait).